### PR TITLE
Add AI agent documentation, architecture and memory files

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,93 @@
+# AGENTS.md
+
+Instructions pour les agents IA qui travaillent sur ce dépôt.
+
+## Portée
+
+Ces consignes s'appliquent à tout le dépôt `invoice-cms`.
+
+## Vue rapide du projet
+
+- Application de génération et de gestion de factures.
+- Backend : Django 4.2 + Django REST Framework, projet `invoices/`, apps métier dans `apps/`.
+- Frontend : Vue 3 + Vue CLI + Ant Design Vue dans `frontend/`.
+- Authentification : Djoser + token DRF côté API, token stocké dans `localStorage` côté frontend.
+- PDF : templates Django dans `templates/`, génération via `pdfkit`/`wkhtmltopdf`.
+- Dev local : base SQLite par défaut ; production : configuration PostgreSQL Azure dans `invoices/settings_prod.py`.
+
+## Commandes utiles
+
+### Backend
+
+```bash
+python3 -m venv invoices_env
+source invoices_env/bin/activate
+pip install -r requirements.txt
+python3 manage.py migrate
+python3 manage.py runserver
+```
+
+Contrôles recommandés avant de livrer une modification backend :
+
+```bash
+python3 manage.py check
+python3 manage.py test
+```
+
+### Frontend
+
+```bash
+cd frontend
+npm install
+npm run serve
+npm run build
+```
+
+Contrôle recommandé avant de livrer une modification frontend :
+
+```bash
+cd frontend && npm run build
+```
+
+## Conventions de modification
+
+- Préserver la séparation backend/frontend :
+  - API, modèles, serializers, permissions et routes DRF dans `apps/*` et `invoices/`.
+  - UI, routes Vue, store Vuex, helpers et assets dans `frontend/src/`.
+- Ajouter une migration Django pour tout changement de modèle.
+- Ne pas modifier les migrations existantes déjà versionnées, sauf demande explicite.
+- Protéger les données utilisateur : filtrer les querysets par `request.user` pour les ressources privées.
+- Garder les endpoints API sous le préfixe `/api/v1/`.
+- Les vues PDF doivent rester compatibles avec `pdfkit` et les templates Django.
+- Ne pas committer de secrets, tokens, dumps de base de données, fichiers `.env`, `db.sqlite3`, `media/`, `staticfiles/`, `node_modules/` ou builds temporaires.
+
+## Style
+
+### Python/Django
+
+- Suivre le style Django existant du dépôt.
+- Garder les imports simples ; ne pas entourer les imports avec des blocs `try/except`.
+- Utiliser des serializers DRF pour valider les entrées API.
+- Utiliser `get_object_or_404(..., created_by=request.user)` ou une restriction équivalente pour les objets détenus par un utilisateur.
+
+### JavaScript/Vue
+
+- Suivre le style Vue existant : composants `.vue`, Vue Router, Vuex namespaced modules.
+- Utiliser l'alias `@/` pour les imports frontend lorsque c'est cohérent avec le code existant.
+- Garder les appels authentifiés via `frontend/src/utils/auth.js` lorsque l'API exige le token.
+
+## Documentation IA
+
+- `ARCHITECTURE.md` décrit l'organisation technique et les flux principaux.
+- `MEMORY.md` contient la mémoire durable du projet : décisions, invariants, risques connus.
+- `SESSION_NOTES.md` contient les notes de travail courantes et doit être mis à jour à la fin d'une session significative.
+- Mettre ces fichiers à jour lorsque vous découvrez une information durable ou que vous changez une convention.
+
+## Pull requests
+
+Dans le résumé de PR, indiquer :
+
+- ce qui a changé ;
+- les fichiers ou zones principales ;
+- les tests/contrôles exécutés ;
+- les limites connues, notamment si un contrôle n'a pas pu être exécuté pour une raison d'environnement.

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -1,0 +1,189 @@
+# ARCHITECTURE.md
+
+Architecture technique de `invoice-cms`.
+
+## Vue d'ensemble
+
+Le dépôt contient une application full-stack de facturation :
+
+```text
+Navigateur Vue 3
+  -> routes protégées par Vue Router/Vuex
+  -> appels HTTP Axios avec token DRF
+  -> Django / Django REST Framework
+  -> apps métier client, team, invoice
+  -> SQLite en local ou PostgreSQL en production
+  -> templates Django + pdfkit pour les PDFs
+```
+
+Django sert aussi l'application frontend compilée via `TemplateView` et `django-webpack-loader`/assets statiques.
+
+## Arborescence principale
+
+```text
+.
+├── apps/
+│   ├── client/      # Modèle, API et admin des clients
+│   ├── invoice/     # Modèles, API, PDF et rappels email des factures
+│   └── team/        # Modèle et API de l'entreprise/équipe utilisateur
+├── frontend/
+│   ├── public/      # Fichiers publics Vue CLI
+│   └── src/         # Application Vue 3
+├── invoices/        # Projet Django : settings, urls, ASGI/WSGI, sitemap
+├── templates/       # Shell HTML, robots/ads et templates PDF
+├── static/          # Fichiers statiques versionnés simples
+├── manage.py
+├── requirements.txt
+└── requirements-dev.txt
+```
+
+## Backend Django
+
+### Projet `invoices/`
+
+- `invoices/settings.py` : configuration locale, SQLite, DRF, Djoser, CORS, templates et static files.
+- `invoices/settings_prod.py` : surcharge production pour Azure/PostgreSQL, WhiteNoise et email SMTP.
+- `invoices/urls.py` : point d'entrée URL principal.
+- `invoices/sitemaps.py` : sitemap pour les vues statiques.
+
+### Routage API
+
+Les routes principales sont incluses sous `/api/v1/` :
+
+- Djoser : inscription, connexion et endpoints utilisateur.
+- Djoser token auth : obtention/suppression de token.
+- `apps.client.urls` : endpoints clients.
+- `apps.team.urls` : endpoints équipes.
+- `apps.invoice.urls` : endpoints factures, génération PDF et rappels.
+
+Les routes non-API incluent :
+
+- `/admin/` pour Django Admin.
+- `/ads.txt`, `/robots.txt`, `/sitemap.xml`.
+- `/` pour le shell frontend `application.html`.
+
+### Apps métier
+
+#### `apps.team`
+
+- Modèle `Team` : profil entreprise d'un utilisateur.
+- Serializer `TeamSerializer`.
+- ViewSet `TeamViewSet` filtré par utilisateur.
+
+#### `apps.client`
+
+- Modèle `Client` : fiche client appartenant à un utilisateur.
+- Serializer `ClientSerializer`, avec factures imbriquées en lecture seule via `ClientInvoiceSerializer`.
+- ViewSet `ClientViewSet` filtré par utilisateur.
+
+#### `apps.invoice`
+
+- Modèle `Invoice` : facture ou note de crédit, montants, statut, relations `Team`, `Client`, auteur/modificateur.
+- Modèle `Item` : ligne de facture.
+- Serializer `InvoiceSerializer` : création imbriquée des `items`.
+- `InvoiceViewSet` : CRUD factures filtré par `created_by`.
+- `generate_pdf` : rend un template PDF puis retourne un fichier PDF.
+- `send_reminder` : envoie un email de relance avec PDF attaché.
+
+## Frontend Vue
+
+### Entrée et configuration
+
+- `frontend/src/main.js` initialise Vue, Ant Design Vue, Vuex, Vue Router, i18n, Axios et Datadog RUM.
+- `frontend/src/utils/constants.js` définit le titre et l'endpoint API courant.
+- `frontend/src/utils/auth.js` crée une instance Axios qui ajoute le token DRF.
+
+### Routage
+
+`frontend/src/router/index.js` définit les pages principales :
+
+- `/dashboard` : tableau de bord protégé.
+- `/dashboard/my-account` et `/dashboard/my-account/edit-team` : compte et équipe.
+- `/dashboard/clients*` : liste, détail, création et modification client.
+- `/dashboard/invoices*` : liste, détail et création facture.
+- `/sign-in`, `/sign-up`, `/about` : pages publiques.
+
+Les routes avec `meta.requireLogin` redirigent vers `/sign-in` si `store.state.user.isLoggedIn` est faux.
+
+### État utilisateur
+
+`frontend/src/store/user/index.js` conserve :
+
+- `user` : id, username, email ;
+- `isLoggedIn` ;
+- `token`.
+
+`initStore` restaure ces informations depuis `localStorage`.
+
+## Flux fonctionnels clés
+
+### Authentification
+
+1. Le frontend appelle les endpoints Djoser/token sous `/api/v1/`.
+2. Le token reçu est stocké dans `localStorage`.
+3. Les appels authentifiés passent par `authAxios`, qui ajoute `Authorization: Token <token>`.
+4. Vue Router protège les pages dashboard à partir de l'état Vuex.
+
+### Création d'une facture
+
+1. L'utilisateur sélectionne ou renseigne un client et des lignes de facture côté Vue.
+2. Le frontend envoie une facture avec `items` imbriqués à l'API.
+3. `InvoiceSerializer.create()` crée la facture puis les `Item` associés.
+4. `InvoiceViewSet.perform_create()` associe l'utilisateur, l'équipe, le compte bancaire et le numéro de facture.
+5. `Team.first_invoice_number` est incrémenté.
+
+### Génération PDF
+
+1. Le frontend appelle l'endpoint PDF d'une facture authentifiée.
+2. Le backend vérifie que la facture appartient à l'utilisateur.
+3. Django rend `pdf.html` ou `pdf_creditnote.html`.
+4. `pdfkit.from_string()` convertit le HTML en PDF.
+5. La réponse est renvoyée en `application/pdf` avec téléchargement.
+
+### Relance email
+
+1. Le backend récupère la facture et l'équipe de l'utilisateur.
+2. Il prépare un email texte + HTML.
+3. Il génère le PDF de facture et l'attache.
+4. Il envoie l'email via le backend email configuré.
+
+## Configuration et variables d'environnement
+
+### Développement local
+
+Le settings local utilise SQLite et un email backend console. Les variables d'environnement ne sont pas strictement nécessaires sauf pour certains services frontend comme Datadog.
+
+### Production
+
+`invoices/settings_prod.py` attend notamment :
+
+- `WEBSITE_HOSTNAME`
+- `DEBUG`
+- `DBHOST`, `DBNAME`, `DBUSER`, `DBPASS`
+- `ADMIN_NAME`, `ADMIN_EMAIL`
+- `SENDGRID_SERVER`, `SENDGRID_PORT`, `SENDGRID_USERNAME`, `SENDGRID_PASSWORD`
+
+Le frontend Datadog peut utiliser :
+
+- `VUE_APP_DATADOG_APPLICATION_ID`
+- `VUE_APP_DATADOG_CLIENT_TOKEN`
+- `VUE_APP_DATADOG_SITE`
+- `VUE_APP_DATADOG_SERVICE`
+- `VUE_APP_DATADOG_ENV`
+
+## Tests et contrôles recommandés
+
+Backend :
+
+```bash
+python3 manage.py check
+python3 manage.py test
+```
+
+Frontend :
+
+```bash
+cd frontend && npm run build
+```
+
+Pour une modification documentaire seulement, vérifier au minimum le diff Git et, si l'environnement Python est prêt, `python3 manage.py check`.

--- a/MEMORY.md
+++ b/MEMORY.md
@@ -1,0 +1,50 @@
+# MEMORY.md
+
+Mémoire durable du projet `invoice-cms` pour les agents IA.
+
+## Objectif produit
+
+`invoice-cms` est un CMS léger de facturation. Il permet à un utilisateur authentifié de gérer son équipe/entreprise, ses clients, ses factures, leurs lignes, l'émission de PDF et l'envoi de rappels par email.
+
+## Stack actuelle
+
+- Backend : Django 4.2, Django REST Framework, Djoser, authentification par token DRF.
+- Frontend : Vue 3, Vue Router 4, Vuex 4, Ant Design Vue 2, Vue CLI 5.
+- Base locale : SQLite via `invoices/settings.py`.
+- Base production : PostgreSQL Azure via `invoices/settings_prod.py`.
+- Assets statiques production : WhiteNoise.
+- PDFs : `pdfkit` côté Django, templates `templates/pdf.html` et `templates/pdf_creditnote.html`.
+- Observabilité frontend : Datadog RUM initialisé dans `frontend/src/main.js` à partir de variables `VUE_APP_DATADOG_*`.
+
+## Domain model durable
+
+- `Team` représente l'entreprise de l'utilisateur : nom, numéro d'organisation, email, adresse, compte bancaire, prochain numéro de facture.
+- `Client` représente un client appartenant à un utilisateur.
+- `Invoice` représente une facture ou une note de crédit. Elle snapshot les informations client au moment de la création et appartient à un `Team`, un `Client`, `created_by` et `modified_by`.
+- `Item` représente une ligne de facture attachée à une facture.
+- Le numéro de facture est dérivé de `Team.first_invoice_number` puis incrémenté à la création d'une facture.
+
+## Invariants importants
+
+- Les ressources métier privées doivent être limitées à l'utilisateur authentifié.
+- Les endpoints applicatifs restent sous `/api/v1/`.
+- Le frontend suppose que l'API est servie depuis la même origine (`endpoint = '/'` et `axios.defaults.baseURL = '/'`).
+- Le token d'authentification est stocké dans `localStorage` et envoyé sous la forme `Authorization: Token <token>`.
+- Les PDFs dépendent de `wkhtmltopdf` disponible dans l'environnement d'exécution.
+- Les montants utilisent des `DecimalField`; éviter les calculs flottants côté backend.
+
+## Risques connus / dette technique
+
+- `SECRET_KEY` de développement est actuellement codée en dur dans `invoices/settings.py`; ne pas la réutiliser en production.
+- `ALLOWED_HOSTS = ['*']` et `DEBUG = True` dans les settings locaux sont seulement adaptés au développement.
+- `settings_prod.py` lit plusieurs variables d'environnement avec `os.environ[...]`; l'application échoue au démarrage si elles sont absentes.
+- La création d'une facture incrémente `Team.first_invoice_number` sans verrou transactionnel explicite ; attention aux créations concurrentes.
+- Le frontend n'a pas de script de test dédié dans `frontend/package.json`; utiliser au minimum `npm run build` pour vérifier l'intégration.
+
+## Bonnes pratiques pour futures sessions IA
+
+- Lire `AGENTS.md` puis `ARCHITECTURE.md` avant toute modification substantielle.
+- Vérifier `git status --short` avant de modifier pour ne pas écraser un travail en cours.
+- Pour un changement backend : exécuter `python3 manage.py check` et, si possible, `python3 manage.py test`.
+- Pour un changement frontend : exécuter `cd frontend && npm run build` si les dépendances sont installées.
+- Mettre à jour cette mémoire si une décision durable, une convention ou une contrainte importante change.

--- a/SESSION_NOTES.md
+++ b/SESSION_NOTES.md
@@ -1,0 +1,28 @@
+# SESSION_NOTES.md
+
+Notes de session pour les agents IA travaillant sur `invoice-cms`.
+
+## Session du 2026-05-11
+
+### Demande
+
+- Ajouter `AGENTS.md`, `MEMORY.md`, `ARCHITECTURE.md` et `SESSION_NOTES.md` afin de rendre le projet plus compatible avec le travail d'agents IA.
+
+### Travail réalisé
+
+- Création de `AGENTS.md` avec consignes de contribution, commandes utiles, conventions backend/frontend et attentes de PR.
+- Création de `MEMORY.md` avec contexte durable, invariants, dette technique et bonnes pratiques pour futures sessions.
+- Création de `ARCHITECTURE.md` avec vue d'ensemble backend Django, frontend Vue, routage, modèles métier et flux clés.
+- Création de `SESSION_NOTES.md` pour tracer la demande et l'état de la session.
+
+### État connu
+
+- Les changements sont documentaires uniquement.
+- Aucun comportement applicatif n'a été modifié.
+- Les contrôles à exécuter avant livraison sont listés dans `AGENTS.md` et `ARCHITECTURE.md`.
+
+### À faire lors de futures sessions
+
+- Mettre à jour `MEMORY.md` lorsqu'une convention durable ou une contrainte importante change.
+- Mettre à jour `ARCHITECTURE.md` lors d'un changement structurel backend, frontend, API ou infrastructure.
+- Ajouter une nouvelle entrée datée dans ce fichier à la fin de chaque session significative.


### PR DESCRIPTION
### Motivation
- Provide explicit guidance and conventions so AI agents and future contributors can work safely and consistently with the codebase.
- Capture durable project context and known risks to avoid repeating onboarding work and to make decisions reproducible.
- Document the system architecture and common developer commands to speed up local development and reviews.

### Description
- Added `AGENTS.md` with instructions for AI agents, useful commands (`python3 manage.py ...`, `cd frontend && npm run build`), contribution conventions and PR expectations.
- Added `MEMORY.md` containing the durable project memory: product goal, stack, domain model, invariants and known technical debt.
- Added `ARCHITECTURE.md` describing the full-stack architecture, API routing, app responsibilities, frontend flows and environment variables.
- Added `SESSION_NOTES.md` to record the 2026-05-11 documentation session and follow-up actions.

### Testing
- Attempted to run `python3 manage.py check` but it failed because Django is not installed in the current environment (`ModuleNotFoundError: No module named 'django'`).
- No frontend automated build (`cd frontend && npm run build`) or tests were executed in this environment.
- No other automated tests were run because these are documentation-only changes.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a02385e2c848332b9daed51474754a7)