### PR TITLE
Mettre à jour les baselines de dépendances frontend

### DIFF
--- a/SESSION_NOTES.md
+++ b/SESSION_NOTES.md
@@ -26,3 +26,19 @@ Notes de session pour les agents IA travaillant sur `invoice-cms`.
 - Mettre à jour `MEMORY.md` lorsqu'une convention durable ou une contrainte importante change.
 - Mettre à jour `ARCHITECTURE.md` lors d'un changement structurel backend, frontend, API ou infrastructure.
 - Ajouter une nouvelle entrée datée dans ce fichier à la fin de chaque session significative.
+
+## Session du 2026-05-12
+
+### Demande
+
+- Upgrader les dépendances frontend vers les dernières updates.
+
+### Travail réalisé
+
+- Synchronisation des versions minimales déclarées dans `frontend/package.json` avec les versions déjà résolues dans `frontend/package-lock.json` pour Vue, Vue Router, Vuex, Sass et Sass Loader.
+- Maintien du verrou npm cohérent avec les versions déclarées afin de préserver `npm ci`.
+
+### État connu
+
+- Le registre npm était inaccessible depuis l'environnement shell (`403 Forbidden` via le proxy), ce qui a empêché une régénération complète du lockfile vers les dernières versions publiées en ligne.
+- Le build frontend passe avec les dépendances actuellement installées/verrouillées, avec uniquement les avertissements de taille de bundle et de données Browserslist déjà présents.

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -16,10 +16,10 @@
         "js-file-download": "^0.4.12",
         "lodash-es": "^4.17.21",
         "moment": "^2.30.1",
-        "vue": "^3.2.13",
+        "vue": "^3.2.37",
         "vue-i18n": "^9.14.5",
-        "vue-router": "^4.0.3",
-        "vuex": "^4.0.0"
+        "vue-router": "^4.1.2",
+        "vuex": "^4.0.2"
       },
       "devDependencies": {
         "@vue/cli-plugin-babel": "~5.0.8",
@@ -27,8 +27,8 @@
         "@vue/cli-plugin-vuex": "~5.0.8",
         "@vue/cli-service": "~5.0.8",
         "node-polyfill-webpack-plugin": "^2.0.1",
-        "sass": "^1.32.7",
-        "sass-loader": "^12.0.0",
+        "sass": "^1.53.0",
+        "sass-loader": "^12.6.0",
         "webpack-bundle-tracker": "^1.6.0"
       }
     },

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -15,10 +15,10 @@
     "js-file-download": "^0.4.12",
     "lodash-es": "^4.17.21",
     "moment": "^2.30.1",
-    "vue": "^3.2.13",
+    "vue": "^3.2.37",
     "vue-i18n": "^9.14.5",
-    "vue-router": "^4.0.3",
-    "vuex": "^4.0.0"
+    "vue-router": "^4.1.2",
+    "vuex": "^4.0.2"
   },
   "devDependencies": {
     "@vue/cli-plugin-babel": "~5.0.8",
@@ -26,8 +26,8 @@
     "@vue/cli-plugin-vuex": "~5.0.8",
     "@vue/cli-service": "~5.0.8",
     "node-polyfill-webpack-plugin": "^2.0.1",
-    "sass": "^1.32.7",
-    "sass-loader": "^12.0.0",
+    "sass": "^1.53.0",
+    "sass-loader": "^12.6.0",
     "webpack-bundle-tracker": "^1.6.0"
   }
 }


### PR DESCRIPTION
### Motivation
- Synchroniser les plages de version déclarées avec les versions déjà résolues dans le lockfile pour éviter des divergences lors de `npm ci` et préparer une montée de version contrôlée des dépendances frontend.

### Description
- Mise à jour des plages de dépendances dans `frontend/package.json` pour `vue` (`^3.2.37`), `vue-router` (`^4.1.2`), `vuex` (`^4.0.2`), `sass` (`^1.53.0`) et `sass-loader` (`^12.6.0`).
- Harmonisation des métadonnées racine dans `frontend/package-lock.json` pour garder le lockfile cohérent avec `package.json` sans régénérer entièrement le lockfile distant. 
- Ajout d’une entrée dans `SESSION_NOTES.md` documentant les actions réalisées et la limitation d’accès au registre npm rencontrée lors de la session.

### Testing
- `cd frontend && npm run build` — build de production terminé avec succès (avertissements de taille de bundle et Browserslist seulement). 
- Vérification programmée de la synchronisation entre `frontend/package.json` et la section racine de `frontend/package-lock.json` via un script Python — vérification passée. 
- `cd frontend && npm outdated --long` — impossible d’exécuter à cause d’un blocage d’accès au registre npm (proxy retournant `403 Forbidden`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a033ebb463083328181d8a0c4e9cc19)